### PR TITLE
add missing backends source in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apk add --no-cache ffmpeg && \
 USER 1000
 
 COPY ./bot.py /home/bot/bot.py
+COPY ./backends/ /home/bot/backends/
 COPY --from=builder /root/.local /home/bot/.local
 
 WORKDIR /home/bot/


### PR DESCRIPTION
Fixes the current Dockerfile by adding the missing `backends` source via copy.